### PR TITLE
Support for classic structure style files

### DIFF
--- a/packages/colocation/lib/base.js
+++ b/packages/colocation/lib/base.js
@@ -1,4 +1,7 @@
+const path = require('path');
+
 const funnel = require('broccoli-funnel');
+const merge = require('broccoli-merge-trees');
 
 module.exports = class Base {
   constructor(options) {
@@ -18,7 +21,13 @@ module.exports = class Base {
       annotation: 'Funnel (ember-cli-styles-colocation grab files addon style files)',
     });
 
-    return funnel(baseFiles, {
+    const classicStyles = funnel(tree, {
+      srcDir: path.join(srcDir, 'styles', 'component-styles'),
+      destDir,
+      allowEmpty: true,
+    });
+
+    return funnel(merge([baseFiles, classicStyles], { overwrite: true }), {
       include: [`**/*.{${this.extentions},}`],
       exclude: [`**/styles/**/*`],
       allowEmpty: true,

--- a/packages/namespace/addon/utils/generate-default-style-namespace-manifest.js
+++ b/packages/namespace/addon/utils/generate-default-style-namespace-manifest.js
@@ -4,7 +4,8 @@ function formatFullName(stylePath) {
   return stylePath
     .replace(/(\/(styles?|index))?\.(css|less|scss|sass|styl)$/, '')
     .replace(/.*?\//, '')
-    .replace(/^components\//, '');
+    .replace(/^components\//, '')
+    .replace(/^templates\//, '');
 }
 
 export function generateDefaultStyleNamespaceManifest(owner, styleExtensions) {

--- a/packages/namespace/lib/component-names.js
+++ b/packages/namespace/lib/component-names.js
@@ -5,7 +5,10 @@ module.exports = {
   path(actualPath) {
     const { dir, name } = path.parse(actualPath);
 
-    return path.join(dir, name.replace(/(template|component|styles?|index)$/, ''));
+    return path.join(
+      dir.replace(/(templates|components)/g, ''),
+      name.replace(/(template|component|styles?|index)$/g, '')
+    );
   },
 
   class(actualPath, terseClassNames) {

--- a/packages/namespace/tests/acceptance/classic-structure-test.js
+++ b/packages/namespace/tests/acceptance/classic-structure-test.js
@@ -4,7 +4,7 @@ import { setupApplicationTest } from 'ember-qunit';
 
 import styleForSetup from 'dummy/tests/setup/style-for';
 
-module.skip('Acceptance | classic structure', function (hooks) {
+module('Acceptance | classic structure', function (hooks) {
   setupApplicationTest(hooks);
   styleForSetup(hooks);
 

--- a/packages/namespace/tests/dummy/app/templates/components/classic-structure.hbs
+++ b/packages/namespace/tests/dummy/app/templates/components/classic-structure.hbs
@@ -1,1 +1,3 @@
-<span class='classic-structure'></span>
+<div class='{{style-namespace}}'>
+  <span class='classic-structure'></span>
+</div>

--- a/packages/namespace/tests/dummy/app/templates/components/nested/classic-structure-nested.hbs
+++ b/packages/namespace/tests/dummy/app/templates/components/nested/classic-structure-nested.hbs
@@ -1,1 +1,3 @@
-<span class='classic-structure-nested'></span>
+<div class='{{style-namespace}}'>
+  <span class='classic-structure-nested'></span>
+</div>


### PR DESCRIPTION
These need to live under the `(app|addon)/styles/component-style` directory, and not to include the `templates` or `components` in the style file path (but would be in the `.hbs` file path.

Could be nice to have a few more test cases to ensure this is working as expected.